### PR TITLE
モザイクアート作成プログラム中のバグの修正

### DIFF
--- a/calculate_average_color.py
+++ b/calculate_average_color.py
@@ -19,9 +19,9 @@ for image_name in os.listdir('image/euph_part_icon'):
             red   += rgba[0]
             green += rgba[1]
             blue  += rgba[2]
-    red   = int(red   / (im_width*im_height))
-    green = int(green / (im_width*im_height))
-    blue  = int(blue  / (im_width*im_height))
+    red   = round(red   / (im_width*im_height))
+    green = round(green / (im_width*im_height))
+    blue  = round(blue  / (im_width*im_height))
     data_list.append([image_name, red, green, blue])
 
 with open('average_color.csv', 'w', newline='') as csv_file:

--- a/mosaic_art.py
+++ b/mosaic_art.py
@@ -32,11 +32,11 @@ for left in range(0, icon_im_width, DOT_AREA_ONE_SIDE):
         green = int(green / (DOT_AREA_ONE_SIDE*DOT_AREA_ONE_SIDE))
         blue  = int(blue  / (DOT_AREA_ONE_SIDE*DOT_AREA_ONE_SIDE))
 
-        distance = 10000
+        distance = 255**2 * 3 # 最大の距離
         filename = ''
         # 色の差が最小になるファイルを決定(距離に見立てている)
         for color in color_data:
-            d = (red-int(color[1]))^2 + (green-int(color[2]))^2 + (blue-int(color[3]))^2
+            d = (red-int(color[1]))**2 + (green-int(color[2]))**2 + (blue-int(color[3]))**2
             if d < distance:
                 distance = d
                 filename = color[0]

--- a/mosaic_art.py
+++ b/mosaic_art.py
@@ -28,9 +28,9 @@ for left in range(0, icon_im_width, DOT_AREA_ONE_SIDE):
                 red   += rgba[0]
                 green += rgba[1]
                 blue  += rgba[2]
-        red   = int(red   / (DOT_AREA_ONE_SIDE*DOT_AREA_ONE_SIDE))
-        green = int(green / (DOT_AREA_ONE_SIDE*DOT_AREA_ONE_SIDE))
-        blue  = int(blue  / (DOT_AREA_ONE_SIDE*DOT_AREA_ONE_SIDE))
+        red   = round(red   / (DOT_AREA_ONE_SIDE*DOT_AREA_ONE_SIDE))
+        green = round(green / (DOT_AREA_ONE_SIDE*DOT_AREA_ONE_SIDE))
+        blue  = round(blue  / (DOT_AREA_ONE_SIDE*DOT_AREA_ONE_SIDE))
 
         distance = 255**2 * 3 # 最大の距離
         filename = ''

--- a/mosaic_art.py
+++ b/mosaic_art.py
@@ -45,4 +45,4 @@ for left in range(0, icon_im_width, DOT_AREA_ONE_SIDE):
         area_im.thumbnail((THUMBNAIL_ONE_SIDE, THUMBNAIL_ONE_SIDE))
         mosaic_icon_im.paste(area_im, (left//10 * THUMBNAIL_ONE_SIDE, top//10 * THUMBNAIL_ONE_SIDE))
 
-mosaic_icon_im.save('my_icon_mosaic.png')
+mosaic_icon_im.save('product/my_icon_mosaic.png')


### PR DESCRIPTION
* 平均色算出の際に四捨五入と勘違いして使っていたint()をround()に修正
* 2つの色の間の距離の最大値を理論上の最大値に変更
* 2乗の演算子を^(XOR)だと勘違いしていたので**に修正
* 作成されたPNGファイルの保存先を変更