### PR TITLE
前処理の中で素材画像を縮小するように修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ env/
 
 # Material Pictures
 image/
+material/
 my_icon.png
 
 # Created Pictures

--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,8 @@ image/
 material/
 my_icon.png
 
+# Material Pictures Information
+average_color.csv
+
 # Created Pictures
 product/

--- a/mosaic_art.py
+++ b/mosaic_art.py
@@ -28,9 +28,8 @@ def main():
                 continue
 
             filename = similar_color_filename(average_color, color_data)
-            # 距離最小のファイルを縮小して1600×1600の画像に貼り付け
-            area_im = Image.open('image/euph_part_icon/'+filename)
-            area_im.thumbnail((THUMBNAIL_ONE_SIDE, THUMBNAIL_ONE_SIDE))
+            # 距離最小のファイルを1600×1600の画像に貼り付け
+            area_im = Image.open('material/euph_part_icon/'+filename)
             mosaic_icon_im.paste(area_im, (left//DOT_AREA_ONE_SIDE * THUMBNAIL_ONE_SIDE,
                                            top//DOT_AREA_ONE_SIDE * THUMBNAIL_ONE_SIDE))
 

--- a/thumbnail_image.py
+++ b/thumbnail_image.py
@@ -1,0 +1,13 @@
+import os
+
+from PIL import Image
+
+
+THUMBNAIL_ONE_SIDE = 40
+
+for image_name in os.listdir('image/euph_part_icon'):
+    if not image_name.endswith('.png'):
+        continue
+    im = Image.open('image/euph_part_icon/'+image_name)
+    im.thumbnail((THUMBNAIL_ONE_SIDE, THUMBNAIL_ONE_SIDE))
+    im.save('material/'+image_name)

--- a/thumbnail_image.py
+++ b/thumbnail_image.py
@@ -10,4 +10,4 @@ for image_name in os.listdir('image/euph_part_icon'):
         continue
     im = Image.open('image/euph_part_icon/'+image_name)
     im.thumbnail((THUMBNAIL_ONE_SIDE, THUMBNAIL_ONE_SIDE))
-    im.save('material/'+image_name)
+    im.save('material/euph_part_icon/'+image_name)


### PR DESCRIPTION
feature/thumbnail_imageブランチにて開発していた
モザイクアート作成の前処理として素材画像を縮小する修正を適用。

モザイクアート作成中にモザイクの範囲ごとに画像を縮小する必要がなくなり、
画像の縮小回数は著しく減少。
体感でモザイクアート作成スピードも向上した。