### PR TITLE
平均色算出を共通化

### DIFF
--- a/calculate_average_color.py
+++ b/calculate_average_color.py
@@ -1,8 +1,9 @@
 import os
 import csv
-import statistics as st
 
 from PIL import Image
+
+from mosaic_art import calc
 
 
 data_list = []
@@ -11,18 +12,7 @@ for image_name in os.listdir('image/euph_part_icon'):
         continue
     im = Image.open('image/euph_part_icon/'+image_name)
     im_width, im_height = im.size
-    red_values   = []
-    green_values = []
-    blue_values  = []
-    for x in range(0, im_width):
-        for y in range(0, im_height):
-            rgba = im.getpixel((x, y))
-            red_values.append(rgba[0])
-            green_values.append(rgba[1])
-            blue_values.append(rgba[2])
-    red   = round(st.mean(red_values))
-    green = round(st.mean(green_values))
-    blue  = round(st.mean(blue_values))
+    red, green, blue = calc.average_color_in_range(im, 0, 0, im_width, im_height)
     data_list.append([image_name, red, green, blue])
 
 with open('average_color.csv', 'w', newline='') as csv_file:

--- a/mosaic_art.py
+++ b/mosaic_art.py
@@ -1,7 +1,8 @@
 import csv
-import statistics as st
 
 from PIL import Image
+
+from mosaic_art import calc
 
 
 DOT_AREA_ONE_SIDE = 10
@@ -23,7 +24,7 @@ def main():
 
     for left in range(0, icon_im_width, DOT_AREA_ONE_SIDE):
         for top in range(0, icon_im_height, DOT_AREA_ONE_SIDE):
-            average_color = average_color_in_range(icon_im, left, top,
+            average_color = calc.average_color_in_range(icon_im, left, top,
                                 left+DOT_AREA_ONE_SIDE, top+DOT_AREA_ONE_SIDE)
             if len(average_color) != 3:
                 continue
@@ -65,41 +66,6 @@ def materials_list_from_file(filename):
                           int(row[POS_GREEN]), int(row[POS_BLUE]))
             color_data.append(image_info)
     return color_data
-
-def average_color_in_range(icon_im, left, top, right, bottom):
-    """Returns the average color of pixels in a given region
-
-    Args:
-        icon_im: Image object of Pillow
-        left: X coordinate of the upper left point of the given region
-        top:  Y coordinate of the upper left point of the given region
-            NOTICE: (left, top) is included in the given region
-        right:  X coordinate of the lower right point of the given area
-        bottom: Y coordinate of the lower right point of the given area
-            NOTICE: (right, bottom) is NOT included in the given region
-
-    Returns:
-        A tuple which means (R, G, B)
-    """
-    if left >= right: # 引数は left < right と想定
-        print('left', left, '>= right', right)
-        return ()
-    if top >= bottom: # 引数は top < bottom と想定
-        print('bottom', bottom, '>= top', top)
-        return ()
-    red_values   = []
-    green_values = []
-    blue_values  = []
-    for x in range(left, right):
-        for y in range(top, bottom):
-            rgba = icon_im.getpixel((x, y))
-            red_values.append(rgba[0])
-            green_values.append(rgba[1])
-            blue_values.append(rgba[2])
-    red   = round(st.mean(red_values))
-    green = round(st.mean(green_values))
-    blue  = round(st.mean(blue_values))
-    return (red, green, blue)
 
 def color_distance(RGB1, RGB2):
     """Returns color distance

--- a/mosaic_art/calc.py
+++ b/mosaic_art/calc.py
@@ -1,0 +1,34 @@
+def average_color_in_range(icon_im, left, top, right, bottom):
+    """Returns the average color of pixels in a given region
+
+    Args:
+        icon_im: Image object of Pillow
+        left: X coordinate of the upper left point of the given region
+        top:  Y coordinate of the upper left point of the given region
+            NOTICE: (left, top) is included in the given region
+        right:  X coordinate of the lower right point of the given area
+        bottom: Y coordinate of the lower right point of the given area
+            NOTICE: (right, bottom) is NOT included in the given region
+
+    Returns:
+        A tuple which means (R, G, B)
+    """
+    if left >= right: # 引数は left < right と想定
+        print('left', left, '>= right', right)
+        return ()
+    if top >= bottom: # 引数は top < bottom と想定
+        print('bottom', bottom, '>= top', top)
+        return ()
+    red_values   = []
+    green_values = []
+    blue_values  = []
+    for x in range(left, right):
+        for y in range(top, bottom):
+            rgba = icon_im.getpixel((x, y))
+            red_values.append(rgba[0])
+            green_values.append(rgba[1])
+            blue_values.append(rgba[2])
+    red   = round(st.mean(red_values))
+    green = round(st.mean(green_values))
+    blue  = round(st.mean(blue_values))
+    return (red, green, blue)

--- a/mosaic_art/calc.py
+++ b/mosaic_art/calc.py
@@ -1,3 +1,6 @@
+import statistics as st
+
+
 def average_color_in_range(icon_im, left, top, right, bottom):
     """Returns the average color of pixels in a given region
 


### PR DESCRIPTION
モザイクアート作成中の平均色算出処理と各素材画像の平均色算出処理が同じロジックだったので、
共通処理をモジュール化し、モジュールの処理を呼び出すように両処理を変更。