### PR TITLE
モザイクアート作成に最頻値を使う機能追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ my_icon.png
 
 # Material Pictures Information
 average_color.csv
+mode_color.csv
 
 # Created Pictures
 product/

--- a/calculate_mode_color.py
+++ b/calculate_mode_color.py
@@ -1,0 +1,20 @@
+import os
+import csv
+
+from PIL import Image
+
+from mosaic_art import calc
+
+
+data_list = []
+for image_name in os.listdir('image/euph_part_icon'):
+    if not image_name.endswith('.png'):
+        continue
+    im = Image.open('image/euph_part_icon/'+image_name)
+    im_width, im_height = im.size
+    red, green, blue = calc.mode_color_in_range(im, 0, 0, im_width, im_height)
+    data_list.append([image_name, red, green, blue])
+
+with open('mode_color.csv', 'w', newline='') as csv_file:
+    csv_writer = csv.writer(csv_file)
+    csv_writer.writerows(data_list)

--- a/mosaic_art/calc.py
+++ b/mosaic_art/calc.py
@@ -35,3 +35,36 @@ def average_color_in_range(icon_im, left, top, right, bottom):
     green = round(st.mean(green_values))
     blue  = round(st.mean(blue_values))
     return (red, green, blue)
+
+def mode_color_in_range(icon_im, left, top, right, bottom):
+    """Returns the mode color of pixels in a given region
+
+    Args:
+        icon_im: Image object of Pillow
+        left: X coordinate of the upper left point of the given region
+        top:  Y coordinate of the upper left point of the given region
+            NOTICE: (left, top) is included in the given region
+        right:  X coordinate of the lower right point of the given area
+        bottom: Y coordinate of the lower right point of the given area
+            NOTICE: (right, bottom) is NOT included in the given region
+
+    Returns:
+        A tuple which means (R, G, B)
+    """
+    if left >= right: # 引数は left < right と想定
+        print('left', left, '>= right', right)
+        return ()
+    if top >= bottom: # 引数は top < bottom と想定
+        print('bottom', bottom, '>= top', top)
+        return ()
+    color_values = []
+    for x in range(left, right):
+        for y in range(top, bottom):
+            rgba = icon_im.getpixel((x, y))
+            color_str = str(rgba[0]).zfill(3)+str(rgba[1]).zfill(3)+str(rgba[2]).zfill(3)
+            color_values.append(color_str)
+    mode_color = st.mode(color_values)
+    red   = int(mode_color[0:2])
+    green = int(mode_color[3:5])
+    blue  = int(mode_color[6:8])
+    return (red, green, blue)

--- a/mosaic_art/calc.py
+++ b/mosaic_art/calc.py
@@ -57,14 +57,27 @@ def mode_color_in_range(icon_im, left, top, right, bottom):
     if top >= bottom: # 引数は top < bottom と想定
         print('bottom', bottom, '>= top', top)
         return ()
+    red_values   = []
+    green_values = []
+    blue_values  = []
     color_values = []
     for x in range(left, right):
         for y in range(top, bottom):
             rgba = icon_im.getpixel((x, y))
+            red_values.append(rgba[0])
+            green_values.append(rgba[1])
+            blue_values.append(rgba[2])
             color_str = str(rgba[0]).zfill(3)+str(rgba[1]).zfill(3)+str(rgba[2]).zfill(3)
             color_values.append(color_str)
-    mode_color = st.mode(color_values)
-    red   = int(mode_color[0:2])
-    green = int(mode_color[3:5])
-    blue  = int(mode_color[6:8])
+    try:
+        mode_color = st.mode(color_values)
+    except st.StatisticsError:
+        # 複数の最頻値がある場合、平均値を返す
+        red   = round(st.mean(red_values))
+        green = round(st.mean(green_values))
+        blue  = round(st.mean(blue_values))
+    else:
+        red   = int(mode_color[0:2])
+        green = int(mode_color[3:5])
+        blue  = int(mode_color[6:8])
     return (red, green, blue)

--- a/mosaic_art_mode.py
+++ b/mosaic_art_mode.py
@@ -1,0 +1,115 @@
+import csv
+
+from PIL import Image
+
+from mosaic_art import calc
+
+
+DOT_AREA_ONE_SIDE = 10
+THUMBNAIL_ONE_SIDE = 40
+# 2つの色(R,G,B)の間の最大の距離
+MAX_COLOR_DISTANCE = 255**2 * 3
+# CSVファイル中のカラムの意味づけ
+POS_NAME  = 0
+POS_RED   = 1
+POS_GREEN = 2
+POS_BLUE  = 3
+
+def main():
+    color_data = materials_list_from_file('mode_color.csv')
+
+    icon_im = Image.open('my_icon.png')
+    icon_im_width, icon_im_height = icon_im.size
+    mosaic_icon_im = Image.new('RGBA', (1600, 1600))
+
+    for left in range(0, icon_im_width, DOT_AREA_ONE_SIDE):
+        for top in range(0, icon_im_height, DOT_AREA_ONE_SIDE):
+            mode_color = calc.mode_color_in_range(icon_im, left, top,
+                                left+DOT_AREA_ONE_SIDE, top+DOT_AREA_ONE_SIDE)
+            if len(mode_color) != 3:
+                continue
+
+            filename = similar_color_filename(mode_color, color_data)
+            # 距離最小のファイルを1600×1600の画像に貼り付け
+            area_im = Image.open('material/euph_part_icon/'+filename)
+            mosaic_icon_im.paste(area_im, (left//DOT_AREA_ONE_SIDE * THUMBNAIL_ONE_SIDE,
+                                           top//DOT_AREA_ONE_SIDE * THUMBNAIL_ONE_SIDE))
+
+    mosaic_icon_im.save('product/my_icon_mosaic_mode.png')
+
+# このファイルではmodeになっているので注意
+def materials_list_from_file(filename):
+    """Returns a list which contains material image information.
+
+    Args:
+        filename: File name such as "foo.csv"
+            The file contains information on average color of image.
+            (Average color maens the average of the values of R of all pixels,
+             the average of the values of G of all pixels,
+             and the average of the values of B of all pixels)
+            A row is as follows:
+                image_name, R_average, G_average, B_average
+
+    Returns:
+        A list of tuples
+        Tuple is like (
+            image_name   : str (such as "bar.png"),
+            red_average  : int,
+            green_average: int,
+            blue_average : int
+            )
+    """
+    color_data = []
+    with open(filename, 'r', newline='') as csvfile:
+        reader = csv.reader(csvfile)
+        for row in reader:
+            image_info = (row[POS_NAME], int(row[POS_RED]),
+                          int(row[POS_GREEN]), int(row[POS_BLUE]))
+            color_data.append(image_info)
+    return color_data
+
+def color_distance(RGB1, RGB2):
+    """Returns color distance
+
+    Considering the distance between two points
+    (x1, y1, z1) and (x2, y2, z2) in three dimensions
+
+    Args:
+        RGB1: A tuple which means (R, G, B)
+        RGB2: A tuple which means (R, G, B)
+
+    Returns:
+        color distance(:int)
+
+    """
+    d2_r = (RGB1[0] - RGB2[0]) ** 2
+    d2_g = (RGB1[1] - RGB2[1]) ** 2
+    d2_b = (RGB1[2] - RGB2[2]) ** 2
+    return d2_r + d2_g + d2_b
+
+def similar_color_filename(average_color, color_data):
+    """Returns name of file similar to average color
+
+    Find the image with average color closest to `average_color` from `color_data`
+
+    Args:
+        average_color: a tuple which means (R, G, B) of average color of a certain range
+        color_data: A list of tuples
+                    Tuple is like (image_name, red_average, green_average, blue_average)
+
+    Returns:
+        A name of file such as 'foo.png' (NOT path)
+    """
+    distance = MAX_COLOR_DISTANCE
+    filename = ''
+    # 色の差が最小になるファイルを決定(距離に見立てている)
+    for color in color_data:
+        sample_color = (color[POS_RED], color[POS_GREEN], color[POS_BLUE])
+        d = color_distance(average_color, sample_color)
+        if d < distance:
+            distance = d
+            filename = color[POS_NAME]
+    return filename
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
* 指定した範囲の画像から色の最頻値を計算するメソッドをモジュールに追加
* 素材画像の最頻値を計算する前処理用のファイルを追加
* 最頻値を使ってモザイクアートを作成するファイルを追加
（ファイルを追加せずに引数で平均色を使うか最頻値を使うか区別したかったが、最頻値を使う機能を追加することを優先した）