### PR TITLE
[bugfix] RGBではない形式で色の情報を持つ画像へ対応した

### DIFF
--- a/calculate_material_color.py
+++ b/calculate_material_color.py
@@ -6,6 +6,7 @@ import sys
 from PIL import Image
 
 from mosaic_art import calc
+from mosaic_art import image_process
 
 
 class CalcType(Enum):
@@ -39,7 +40,7 @@ class ColorCalculator:
         for image_name in os.listdir('image/euph_part_icon'):
             if not image_name.endswith('.png'):
                 continue
-            im = Image.open('image/euph_part_icon/'+image_name)
+            im = image_process.open_image_RGB('image/euph_part_icon/'+image_name)
             im_width, im_height = im.size
             red, green, blue = self.calc_func(im, 0, 0, im_width, im_height)
             data_list.append([image_name, red, green, blue])

--- a/dot_picture.py
+++ b/dot_picture.py
@@ -2,7 +2,25 @@ from PIL import Image
 
 DOT_AREA_ONE_SIDE = 10
 
-icon_im = Image.open('my_icon.png')
+def open_RGBA_image(image_path):
+    """Open a image in 'RGBA' mode
+
+    Args:
+        image_path: str
+            image file path
+
+    Returns:
+        Image Object
+            always 'RGBA' mode
+    """
+    im = Image.open(image_path)
+    if im.mode != 'RGBA':
+        print('convert to RGBA from {0}: {1}'.format(im.mode, image_path))
+        return im.convert('RGBA')
+    else:
+        return im
+
+icon_im = open_RGBA_image('my_icon.png')
 icon_im_width, icon_im_height = icon_im.size
 dot_icon_im = icon_im.copy()
 

--- a/dot_picture.py
+++ b/dot_picture.py
@@ -1,26 +1,10 @@
 from PIL import Image
 
+from mosaic_art import image_process
+
 DOT_AREA_ONE_SIDE = 10
 
-def open_RGBA_image(image_path):
-    """Open a image in 'RGBA' mode
-
-    Args:
-        image_path: str
-            image file path
-
-    Returns:
-        Image Object
-            always 'RGBA' mode
-    """
-    im = Image.open(image_path)
-    if im.mode != 'RGBA':
-        print('convert to RGBA from {0}: {1}'.format(im.mode, image_path))
-        return im.convert('RGBA')
-    else:
-        return im
-
-icon_im = open_RGBA_image('my_icon.png')
+icon_im = image_process.open_image_RGB('my_icon.png')
 icon_im_width, icon_im_height = icon_im.size
 dot_icon_im = icon_im.copy()
 

--- a/dot_picture.py
+++ b/dot_picture.py
@@ -2,6 +2,7 @@ from PIL import Image
 
 from mosaic_art import image_process
 
+
 DOT_AREA_ONE_SIDE = 10
 
 icon_im = image_process.open_image_RGB('my_icon.png')

--- a/mosaic_art.py
+++ b/mosaic_art.py
@@ -18,7 +18,7 @@ POS_BLUE  = 3
 def main():
     color_data = materials_list_from_file('average_color.csv')
 
-    icon_im = Image.open('my_icon.png')
+    icon_im = open_RGBA_image('my_icon.png')
     icon_im_width, icon_im_height = icon_im.size
     mosaic_icon_im = Image.new('RGBA', (1600, 1600))
 

--- a/mosaic_art.py
+++ b/mosaic_art.py
@@ -37,6 +37,24 @@ def main():
 
     mosaic_icon_im.save('product/my_icon_mosaic.png')
 
+def open_RGBA_image(image_path):
+    """Open a image in 'RGBA' mode
+
+    Args:
+        image_path: str
+            image file path
+
+    Returns:
+        Image Object
+            always 'RGBA' mode
+    """
+    im = Image.open(image_path)
+    if im.mode != 'RGBA':
+        print('convert to RGBA from {0}: {1}'.format(im.mode, image_path))
+        return im.convert('RGBA')
+    else:
+        return im
+
 def materials_list_from_file(filename):
     """Returns a list which contains material image information.
 

--- a/mosaic_art.py
+++ b/mosaic_art.py
@@ -3,6 +3,7 @@ import csv
 from PIL import Image
 
 from mosaic_art import calc
+from mosaic_art import image_process
 
 
 DOT_AREA_ONE_SIDE = 10
@@ -18,7 +19,7 @@ POS_BLUE  = 3
 def main():
     color_data = materials_list_from_file('average_color.csv')
 
-    icon_im = open_RGBA_image('my_icon.png')
+    icon_im = image_process.open_image_RGB('my_icon.png')
     icon_im_width, icon_im_height = icon_im.size
     mosaic_icon_im = Image.new('RGBA', (1600, 1600))
 
@@ -36,24 +37,6 @@ def main():
                                            top//DOT_AREA_ONE_SIDE * THUMBNAIL_ONE_SIDE))
 
     mosaic_icon_im.save('product/my_icon_mosaic.png')
-
-def open_RGBA_image(image_path):
-    """Open a image in 'RGBA' mode
-
-    Args:
-        image_path: str
-            image file path
-
-    Returns:
-        Image Object
-            always 'RGBA' mode
-    """
-    im = Image.open(image_path)
-    if im.mode != 'RGBA':
-        print('convert to RGBA from {0}: {1}'.format(im.mode, image_path))
-        return im.convert('RGBA')
-    else:
-        return im
 
 def materials_list_from_file(filename):
     """Returns a list which contains material image information.

--- a/mosaic_art/image_process.py
+++ b/mosaic_art/image_process.py
@@ -1,0 +1,22 @@
+from PIL import Image
+
+
+def open_image_RGB(image_path):
+    """Open a image in a mode that can provide RGB values.
+    If RGB values cannot be acquired from a image,
+    convert the image to 'RGBA' mode.
+
+    Args:
+        image_path: str
+            image file path
+
+    Returns:
+        Image Object
+            'RGBA' or 'RGB' mode
+    """
+    im = Image.open(image_path)
+    if not im.mode in ['RGBA', 'RGB']:
+        print('convert to RGBA from {0}: {1}'.format(im.mode, image_path))
+        return im.convert('RGBA')
+    else:
+        return im

--- a/mosaic_art_median.py
+++ b/mosaic_art_median.py
@@ -18,7 +18,7 @@ POS_BLUE  = 3
 def main():
     color_data = materials_list_from_file('median_color.csv')
 
-    icon_im = Image.open('my_icon.png')
+    icon_im = open_RGBA_image('my_icon.png')
     icon_im_width, icon_im_height = icon_im.size
     mosaic_icon_im = Image.new('RGBA', (1600, 1600))
 
@@ -36,6 +36,24 @@ def main():
                                            top//DOT_AREA_ONE_SIDE * THUMBNAIL_ONE_SIDE))
 
     mosaic_icon_im.save('product/my_icon_mosaic_median.png')
+
+def open_RGBA_image(image_path):
+    """Open a image in 'RGBA' mode
+
+    Args:
+        image_path: str
+            image file path
+
+    Returns:
+        Image Object
+            always 'RGBA' mode
+    """
+    im = Image.open(image_path)
+    if im.mode != 'RGBA':
+        print('convert to RGBA from {0}: {1}'.format(im.mode, image_path))
+        return im.convert('RGBA')
+    else:
+        return im
 
 # このファイルではmedianになっているので注意
 def materials_list_from_file(filename):

--- a/mosaic_art_median.py
+++ b/mosaic_art_median.py
@@ -3,6 +3,7 @@ import csv
 from PIL import Image
 
 from mosaic_art import calc
+from mosaic_art import image_process
 
 
 DOT_AREA_ONE_SIDE = 10
@@ -18,7 +19,7 @@ POS_BLUE  = 3
 def main():
     color_data = materials_list_from_file('median_color.csv')
 
-    icon_im = open_RGBA_image('my_icon.png')
+    icon_im = image_process.open_image_RGB('my_icon.png')
     icon_im_width, icon_im_height = icon_im.size
     mosaic_icon_im = Image.new('RGBA', (1600, 1600))
 
@@ -36,24 +37,6 @@ def main():
                                            top//DOT_AREA_ONE_SIDE * THUMBNAIL_ONE_SIDE))
 
     mosaic_icon_im.save('product/my_icon_mosaic_median.png')
-
-def open_RGBA_image(image_path):
-    """Open a image in 'RGBA' mode
-
-    Args:
-        image_path: str
-            image file path
-
-    Returns:
-        Image Object
-            always 'RGBA' mode
-    """
-    im = Image.open(image_path)
-    if im.mode != 'RGBA':
-        print('convert to RGBA from {0}: {1}'.format(im.mode, image_path))
-        return im.convert('RGBA')
-    else:
-        return im
 
 # このファイルではmedianになっているので注意
 def materials_list_from_file(filename):

--- a/mosaic_art_mode.py
+++ b/mosaic_art_mode.py
@@ -3,6 +3,7 @@ import csv
 from PIL import Image
 
 from mosaic_art import calc
+from mosaic_art import image_process
 
 
 DOT_AREA_ONE_SIDE = 10
@@ -18,7 +19,7 @@ POS_BLUE  = 3
 def main():
     color_data = materials_list_from_file('mode_color.csv')
 
-    icon_im = open_RGBA_image('my_icon.png')
+    icon_im = image_process.open_image_RGB('my_icon.png')
     icon_im_width, icon_im_height = icon_im.size
     mosaic_icon_im = Image.new('RGBA', (1600, 1600))
 
@@ -36,24 +37,6 @@ def main():
                                            top//DOT_AREA_ONE_SIDE * THUMBNAIL_ONE_SIDE))
 
     mosaic_icon_im.save('product/my_icon_mosaic_mode.png')
-
-def open_RGBA_image(image_path):
-    """Open a image in 'RGBA' mode
-
-    Args:
-        image_path: str
-            image file path
-
-    Returns:
-        Image Object
-            always 'RGBA' mode
-    """
-    im = Image.open(image_path)
-    if im.mode != 'RGBA':
-        print('convert to RGBA from {0}: {1}'.format(im.mode, image_path))
-        return im.convert('RGBA')
-    else:
-        return im
 
 # このファイルではmodeになっているので注意
 def materials_list_from_file(filename):

--- a/mosaic_art_mode.py
+++ b/mosaic_art_mode.py
@@ -18,7 +18,7 @@ POS_BLUE  = 3
 def main():
     color_data = materials_list_from_file('mode_color.csv')
 
-    icon_im = Image.open('my_icon.png')
+    icon_im = open_RGBA_image('my_icon.png')
     icon_im_width, icon_im_height = icon_im.size
     mosaic_icon_im = Image.new('RGBA', (1600, 1600))
 
@@ -36,6 +36,24 @@ def main():
                                            top//DOT_AREA_ONE_SIDE * THUMBNAIL_ONE_SIDE))
 
     mosaic_icon_im.save('product/my_icon_mosaic_mode.png')
+
+def open_RGBA_image(image_path):
+    """Open a image in 'RGBA' mode
+
+    Args:
+        image_path: str
+            image file path
+
+    Returns:
+        Image Object
+            always 'RGBA' mode
+    """
+    im = Image.open(image_path)
+    if im.mode != 'RGBA':
+        print('convert to RGBA from {0}: {1}'.format(im.mode, image_path))
+        return im.convert('RGBA')
+    else:
+        return im
 
 # このファイルではmodeになっているので注意
 def materials_list_from_file(filename):


### PR DESCRIPTION
#12「Slackのロゴでモザイクアートを作成しようとしたところ、IndexErrorが解決できない」
にて判明したように、
RGBの3つの色情報が取れない画像ではモザイクアートが作成できないという問題があった。

開いた画像のmodeを確認し、RGBの情報が取れないmodeの場合は
画像をRGBA modeに変換する関数を用意した。
色を計算する前の画像のopenをその処理で置き換えた。
（これにより色の計算で3つの色情報が取れずに処理が落ちることはなくなった）
[#12 のコメント](https://github.com/ftnext/mosaic-art-python/issues/12#issuecomment-367654845)で洗い出したファイルで置き換えを実施している。

当初は各ファイルで個別に関数を実装していたが、その実装では不十分なことがわかった。
（素材画像にRGBの画像が多く、これらからはRGBの値が取れるので、RGBAに変換しないものとした）
問題を解決した関数をモジュールに定義し、それを各ファイルで呼び出すようにした。