### PR TITLE
Bugfix/#19 対象画像を引数で指定するように変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ https://speakerdeck.com/ftnext/pillow-mosaic-art-nyumon
 * ┣ product/ :作成後のモザイクアートが置かれる
 
 * ┣ README.md
-* ┣ my_icon.png :モザイクアート対象画像
+* ┣ my_icon.png :モザイクアート対象画像 (ただし、ここに配置しなくてもよい)
 
   前処理で使うファイル
 * ┣ calculate_material_color.py
@@ -47,13 +47,13 @@ https://speakerdeck.com/ftnext/pillow-mosaic-art-nyumon
 * ┗ dot_picture.py :notebookで使っているメソッドの元
 
 # 注意点
-* 対象画像は `my_icon.png` という名前で配置してください。
 * 素材画像は`image/`フォルダの下に`euph_part_icon`というフォルダを作ってその中に配置してください。
 * 前処理で`python thumbnail_image.py`を実行する前に、`material/`フォルダの下に`euph_part_icon`というフォルダを作ってください。
 * 対象画像、素材画像ともに 400×400 のサイズでしか正常に動作しないと思われます。
 * できあがるモザイクアートのサイズは 1600×1600 になります。対象画像を 10×10 の領域に分割し、各領域に 40×40 のサイズの素材画像のうち一番色が近いものを対応させています。
 
 パスの決め打ち問題や、一定のサイズにしか対応できない点は実装不足なので、今後ソースコードを更新していく。
+(対象画像のファイル名の決め打ち問題は対応済み)
 
 # 前処理
 1. image/フォルダ以下に素材画像を配置する
@@ -64,7 +64,8 @@ https://speakerdeck.com/ftnext/pillow-mosaic-art-nyumon
 * 色の最頻値で素材画像を代表させる場合: `python calculate_material_color.py mode` → mode_color.csvが作成される
 
 # モザイクアート作成
-対象画像を my_icon.png として配置する。
+対象画像を上記のように my_icon.png として配置したとする。
+([Issue#19](https://github.com/ftnext/mosaic-art-python/issues/19)対応で対象画像をフルパスで指定できるように修正しています)
 
 モザイクアート作成時、以下の2点を指定している。
 * 対象画像を格子状に分割した領域をどのような色で代表させるか (平均値／中央値／最頻値)
@@ -73,13 +74,14 @@ https://speakerdeck.com/ftnext/pillow-mosaic-art-nyumon
 後者は average_color.csv, median_color.csv, mode_color.csvのうちどれを使うかということ。
 
 色の代表のさせ方については以下の組合せを提供している。
-* 平均値×平均値: 対象画像の領域の色を *平均値* で代表させ、素材画像の色を *平均値* で代表させる: `python mosaic_art.py`
-* 中央値×中央値: 対象画像の領域の色を *中央値* で代表させ、素材画像の色を *中央値* で代表させる: `python mosaic_art_median.py`
-* 最頻値×最頻値: 対象画像の領域の色を *最頻値* で代表させ、素材画像の色を *最頻値* で代表させる: `python mosaic_art_mode.py`
+* 平均値×平均値: 対象画像の領域の色を *平均値* で代表させ、素材画像の色を *平均値* で代表させる: `python mosaic_art.py my_icon.png`
+* 中央値×中央値: 対象画像の領域の色を *中央値* で代表させ、素材画像の色を *中央値* で代表させる: `python mosaic_art_median.py my_icon.png`
+* 最頻値×最頻値: 対象画像の領域の色を *最頻値* で代表させ、素材画像の色を *最頻値* で代表させる: `python mosaic_art_mode.py my_icon.png`
 
 以上3つのコマンドのいずれかを実行すると、product/フォルダにモザイクアートにした画像ができる。
-* `python mosaic_art.py` → product/my_icon_mosaic.png
-* `python mosaic_art_median.py` → product/my_icon_mosaic_median.png
-* `python mosaic_art_mode.py` → product/my_icon_mosaic_mode.png
+**注意: 作成したモザイクアートのファイル名は以下のように固定される**
+* `python mosaic_art.py my_icon.png` → product/my_icon_mosaic.png
+* `python mosaic_art_median.py my_icon.png` → product/my_icon_mosaic_median.png
+* `python mosaic_art_mode.py my_icon.png` → product/my_icon_mosaic_mode.png
 
 READMEを書いている時点では **平均値×平均値** の組合せを推奨する。

--- a/mosaic_art.py
+++ b/mosaic_art.py
@@ -1,4 +1,5 @@
 import csv
+import os.path
 
 from PIL import Image
 
@@ -24,6 +25,14 @@ def validate_image_format(image):
         image: target image file path (:str)
     """
     return image.endswith('png') or image.endswith('jpg')
+
+def exists_file(file):
+    """Verify that the file exists
+
+    Args:
+        file: target file path (:str)
+    """
+    return os.path.exists(file)
 
 def show_usage():
     """Displays usage along with error message

--- a/mosaic_art.py
+++ b/mosaic_art.py
@@ -1,9 +1,9 @@
 import csv
-import os.path
 import sys
 
 from PIL import Image
 
+from mosaic_art import args_validation
 from mosaic_art import calc
 from mosaic_art import image_process
 
@@ -20,55 +20,10 @@ POS_BLUE  = 3
 
 def main():
     args = sys.argv
-    if validate(args):
+    if args_validation.validate(args):
         create_mosaic_art(args[1])
     else:
         sys.exit('Terminate without creating mosaic art due to argument error')
-
-def validate(args):
-    """Validates arguments
-
-    Args:
-        args: list of arguments
-    """
-    if len(args) > 2:
-        print('Too Many arguments:', args)
-        show_usage()
-        return False
-    elif len(args) == 1:
-        print('Missing arguments')
-        show_usage()
-        return False
-    if not validate_image_format(args[1]):
-        print('image file is not PNG or JPEG:', args[1])
-        show_usage()
-        return False
-    if not exists_file(args[1]):
-        print('image file does not exist:', args[1])
-        show_usage()
-        return False
-    return True
-
-def validate_image_format(image):
-    """Verify that the image file path is PNG or JPEG
-
-    Args:
-        image: target image file path (:str)
-    """
-    return image.endswith('png') or image.endswith('jpg')
-
-def exists_file(file):
-    """Verify that the file exists
-
-    Args:
-        file: target file path (:str)
-    """
-    return os.path.exists(file)
-
-def show_usage():
-    """Displays usage along with error message
-    """
-    print('[Usage] python mosaic_art.py target/image/path')
 
 def create_mosaic_art(target_im):
     """Creates mosaic art from target image

--- a/mosaic_art.py
+++ b/mosaic_art.py
@@ -18,6 +18,30 @@ POS_GREEN = 2
 POS_BLUE  = 3
 
 def main():
+def validate(args):
+    """Validates arguments
+
+    Args:
+        args: list of arguments
+    """
+    if len(args) > 2:
+        print('Too Many arguments:', args)
+        show_usage()
+        return False
+    elif len(args) == 1:
+        print('Missing arguments')
+        show_usage()
+        return False
+    if not validate_image_format(args[1]):
+        print('image file is not PNG or JPEG:', args[1])
+        show_usage()
+        return False
+    if not exists_file(args[1]):
+        print('image file does not exist:', args[1])
+        show_usage()
+        return False
+    return True
+
 def validate_image_format(image):
     """Verify that the image file path is PNG or JPEG
 

--- a/mosaic_art.py
+++ b/mosaic_art.py
@@ -17,6 +17,14 @@ POS_GREEN = 2
 POS_BLUE  = 3
 
 def main():
+def validate_image_format(image):
+    """Verify that the image file path is PNG or JPEG
+
+    Args:
+        image: target image file path (:str)
+    """
+    return image.endswith('png') or image.endswith('jpg')
+
 def show_usage():
     """Displays usage along with error message
     """

--- a/mosaic_art.py
+++ b/mosaic_art.py
@@ -17,9 +17,16 @@ POS_GREEN = 2
 POS_BLUE  = 3
 
 def main():
+def create_mosaic_art(target_im):
+    """Creates mosaic art from target image
+
+    Args:
+        target_im: path of target image file (:str)
+            example: 'foo/bar.png'
+    """
     color_data = materials_list_from_file('average_color.csv')
 
-    icon_im = image_process.open_image_RGB('my_icon.png')
+    icon_im = image_process.open_image_RGB(target_im)
     icon_im_width, icon_im_height = icon_im.size
     mosaic_icon_im = Image.new('RGBA', (1600, 1600))
 

--- a/mosaic_art.py
+++ b/mosaic_art.py
@@ -1,5 +1,6 @@
 import csv
 import os.path
+import sys
 
 from PIL import Image
 
@@ -18,6 +19,12 @@ POS_GREEN = 2
 POS_BLUE  = 3
 
 def main():
+    args = sys.argv
+    if validate(args):
+        create_mosaic_art(args[1])
+    else:
+        sys.exit('Terminate without creating mosaic art due to argument error')
+
 def validate(args):
     """Validates arguments
 

--- a/mosaic_art.py
+++ b/mosaic_art.py
@@ -17,6 +17,11 @@ POS_GREEN = 2
 POS_BLUE  = 3
 
 def main():
+def show_usage():
+    """Displays usage along with error message
+    """
+    print('[Usage] python mosaic_art.py target/image/path')
+
 def create_mosaic_art(target_im):
     """Creates mosaic art from target image
 

--- a/mosaic_art/args_validation.py
+++ b/mosaic_art/args_validation.py
@@ -1,0 +1,47 @@
+import os.path
+
+
+def validate(args):
+    """Validates arguments
+
+    Args:
+        args: list of arguments
+    """
+    if len(args) > 2:
+        print('Too Many arguments:', args)
+        show_usage()
+        return False
+    elif len(args) == 1:
+        print('Missing arguments')
+        show_usage()
+        return False
+    if not validate_image_format(args[1]):
+        print('image file is not PNG or JPEG:', args[1])
+        show_usage()
+        return False
+    if not exists_file(args[1]):
+        print('image file does not exist:', args[1])
+        show_usage()
+        return False
+    return True
+
+def validate_image_format(image):
+    """Verify that the image file path is PNG or JPEG
+
+    Args:
+        image: target image file path (:str)
+    """
+    return image.endswith('png') or image.endswith('jpg')
+
+def exists_file(file):
+    """Verify that the file exists
+
+    Args:
+        file: target file path (:str)
+    """
+    return os.path.exists(file)
+
+def show_usage():
+    """Displays usage along with error message
+    """
+    print('[Usage] python mosaic_art.py target/image/path')

--- a/mosaic_art_median.py
+++ b/mosaic_art_median.py
@@ -1,7 +1,9 @@
 import csv
+import sys
 
 from PIL import Image
 
+from mosaic_art import args_validation
 from mosaic_art import calc
 from mosaic_art import image_process
 
@@ -17,9 +19,22 @@ POS_GREEN = 2
 POS_BLUE  = 3
 
 def main():
+    args = sys.argv
+    if args_validation.validate(args):
+        create_mosaic_art_with_median(args[1])
+    else:
+        sys.exit('Terminate without creating mosaic art due to argument error')
+
+def create_mosaic_art_with_median(target_im):
+    """Creates mosaic art from target image with median color
+
+    Args:
+        target_im: path of target image file (:str)
+            example: 'foo/bar.png'
+    """
     color_data = materials_list_from_file('median_color.csv')
 
-    icon_im = image_process.open_image_RGB('my_icon.png')
+    icon_im = image_process.open_image_RGB(target_im)
     icon_im_width, icon_im_height = icon_im.size
     mosaic_icon_im = Image.new('RGBA', (1600, 1600))
 

--- a/mosaic_art_mode.py
+++ b/mosaic_art_mode.py
@@ -1,7 +1,9 @@
 import csv
+import sys
 
 from PIL import Image
 
+from mosaic_art import args_validation
 from mosaic_art import calc
 from mosaic_art import image_process
 
@@ -17,9 +19,22 @@ POS_GREEN = 2
 POS_BLUE  = 3
 
 def main():
+    args = sys.argv
+    if args_validation.validate(args):
+        create_mosaic_art_with_mode(args[1])
+    else:
+        sys.exit('Terminate without creating mosaic art due to argument error')
+
+def create_mosaic_art_with_mode(target_im):
+    """Creates mosaic art from target image with mode color
+
+    Args:
+        target_im: path of target image file (:str)
+            example: 'foo/bar.png'
+    """
     color_data = materials_list_from_file('mode_color.csv')
 
-    icon_im = image_process.open_image_RGB('my_icon.png')
+    icon_im = image_process.open_image_RGB(target_im)
     icon_im_width, icon_im_height = icon_im.size
     mosaic_icon_im = Image.new('RGBA', (1600, 1600))
 


### PR DESCRIPTION
* 対象画像を引数で指定できるようにしたことで、引数のバリデーションが必要になった。
修正が必要な3ファイルに同じコードを入れるのではなく、
以下のコメントにならって、バリデーション処理を1つのモジュールにまとめた。
https://github.com/ftnext/mosaic-art-python/issues/12#issuecomment-367858572

* 平均色、中央色、最瀕色の各場合において、以下のパターンで動作確認した。
    * 対象画像の引数が足りないケース：`python mosaic_art.py`
    * 対象画像の引数が2つ指定されたケース：`python mosaic_art.py my_icon.png my_icon.png`
    * 拡張子がpngでもjpgでもない画像が指定されたケース：`python mosaic_art.py my_icon.svg`
    * 存在しないファイルが指定されたケース：`python mosaic_art.py my_icon2.png`
    * 正常系：`python mosaic_art.py my_icon.png`
    * 正常系2としてリポジトリの外に置いたslackのアイコン画像をフルパスで指定し、動作することを確認した