### PR TITLE
Bugfix/#21 モザイクアートのファイル名の区別

### DIFF
--- a/mosaic_art.py
+++ b/mosaic_art.py
@@ -53,6 +53,23 @@ def create_mosaic_art(target_im):
 
     mosaic_icon_im.save('product/my_icon_mosaic.png')
 
+def extract_file_name(file_path):
+    """Extracts file name from file path (not including extension)
+
+    Args:
+        file_path: str
+            example: 'foo/bar.png'
+
+    Returns:
+        str
+            example: 'bar'
+
+    """
+    # ファイルパスからファイル名(拡張子含む)を取り出す
+    file_name = file_path.split('/')[-1]
+    # 拡張子を取り除く
+    return file_name.split('.')[0]
+
 def materials_list_from_file(filename):
     """Returns a list which contains material image information.
 

--- a/mosaic_art.py
+++ b/mosaic_art.py
@@ -54,6 +54,21 @@ def create_mosaic_art(target_im):
 
     mosaic_icon_im.save('product/my_icon_mosaic.png')
 
+def mosaic_art_file_name(target_im):
+    """Returns a file name from target image name
+
+    Args:
+        target_im: path of target image file (:str)
+            example: 'foo/bar.png'
+
+    Returns:
+        str
+            example: 'bar_mosaic_20180331121251.png'
+    """
+    target_file_name = extract_file_name(target_im)
+    now_dt = now_datetime()
+    return '{0}_mosaic_{1}.png'.format(target_file_name, now_dt)
+
 def extract_file_name(file_path):
     """Extracts file name from file path (not including extension)
 

--- a/mosaic_art.py
+++ b/mosaic_art.py
@@ -1,4 +1,5 @@
 import csv
+import datetime
 import sys
 
 from PIL import Image
@@ -69,6 +70,17 @@ def extract_file_name(file_path):
     file_name = file_path.split('/')[-1]
     # 拡張子を取り除く
     return file_name.split('.')[0]
+
+def now_datetime():
+    """Returns current time as '%Y%m%d%H%M%S' string
+
+    Returns:
+        str
+            example: '20180331121251'
+                current time 2018/3/31 12:12:51
+    """
+    now = datetime.datetime.now()
+    return now.strftime('%Y%m%d%H%M%S')
 
 def materials_list_from_file(filename):
     """Returns a list which contains material image information.

--- a/mosaic_art.py
+++ b/mosaic_art.py
@@ -52,7 +52,9 @@ def create_mosaic_art(target_im):
             mosaic_icon_im.paste(area_im, (left//DOT_AREA_ONE_SIDE * THUMBNAIL_ONE_SIDE,
                                            top//DOT_AREA_ONE_SIDE * THUMBNAIL_ONE_SIDE))
 
-    mosaic_icon_im.save('product/my_icon_mosaic.png')
+    save_file_path = 'product/{}'.format(mosaic_art_file_name(target_im))
+    print('Mosaic art created at', save_file_path)
+    mosaic_icon_im.save(save_file_path)
 
 def mosaic_art_file_name(target_im):
     """Returns a file name from target image name

--- a/mosaic_art_median.py
+++ b/mosaic_art_median.py
@@ -54,6 +54,21 @@ def create_mosaic_art_with_median(target_im):
 
     mosaic_icon_im.save('product/my_icon_mosaic_median.png')
 
+def mosaic_art_median_file_name(target_im):
+    """Returns a file name from target image name
+
+    Args:
+        target_im: path of target image file (:str)
+            example: 'foo/bar.png'
+
+    Returns:
+        str
+            example: 'bar_mosaic_median_20180331121251.png'
+    """
+    target_file_name = extract_file_name(target_im)
+    now_dt = now_datetime()
+    return '{0}_mosaic_median_{1}.png'.format(target_file_name, now_dt)
+
 def extract_file_name(file_path):
     """Extracts file name from file path (not including extension)
 

--- a/mosaic_art_median.py
+++ b/mosaic_art_median.py
@@ -1,4 +1,5 @@
 import csv
+import datetime
 import sys
 
 from PIL import Image
@@ -52,6 +53,34 @@ def create_mosaic_art_with_median(target_im):
                                            top//DOT_AREA_ONE_SIDE * THUMBNAIL_ONE_SIDE))
 
     mosaic_icon_im.save('product/my_icon_mosaic_median.png')
+
+def extract_file_name(file_path):
+    """Extracts file name from file path (not including extension)
+
+    Args:
+        file_path: str
+            example: 'foo/bar.png'
+
+    Returns:
+        str
+            example: 'bar'
+
+    """
+    # ファイルパスからファイル名(拡張子含む)を取り出す
+    file_name = file_path.split('/')[-1]
+    # 拡張子を取り除く
+    return file_name.split('.')[0]
+
+def now_datetime():
+    """Returns current time as '%Y%m%d%H%M%S' string
+
+    Returns:
+        str
+            example: '20180331121251'
+                current time 2018/3/31 12:12:51
+    """
+    now = datetime.datetime.now()
+    return now.strftime('%Y%m%d%H%M%S')
 
 # このファイルではmedianになっているので注意
 def materials_list_from_file(filename):

--- a/mosaic_art_median.py
+++ b/mosaic_art_median.py
@@ -52,7 +52,9 @@ def create_mosaic_art_with_median(target_im):
             mosaic_icon_im.paste(area_im, (left//DOT_AREA_ONE_SIDE * THUMBNAIL_ONE_SIDE,
                                            top//DOT_AREA_ONE_SIDE * THUMBNAIL_ONE_SIDE))
 
-    mosaic_icon_im.save('product/my_icon_mosaic_median.png')
+    save_file_path = 'product/{}'.format(mosaic_art_median_file_name(target_im))
+    print('Mosaic art created at', save_file_path)
+    mosaic_icon_im.save(save_file_path)
 
 def mosaic_art_median_file_name(target_im):
     """Returns a file name from target image name

--- a/mosaic_art_mode.py
+++ b/mosaic_art_mode.py
@@ -54,6 +54,21 @@ def create_mosaic_art_with_mode(target_im):
 
     mosaic_icon_im.save('product/my_icon_mosaic_mode.png')
 
+def mosaic_art_mode_file_name(target_im):
+    """Returns a file name from target image name
+
+    Args:
+        target_im: path of target image file (:str)
+            example: 'foo/bar.png'
+
+    Returns:
+        str
+            example: 'bar_mosaic_mode_20180331121251.png'
+    """
+    target_file_name = extract_file_name(target_im)
+    now_dt = now_datetime()
+    return '{0}_mosaic_mode_{1}.png'.format(target_file_name, now_dt)
+
 def extract_file_name(file_path):
     """Extracts file name from file path (not including extension)
 

--- a/mosaic_art_mode.py
+++ b/mosaic_art_mode.py
@@ -1,4 +1,5 @@
 import csv
+import datetime
 import sys
 
 from PIL import Image
@@ -52,6 +53,34 @@ def create_mosaic_art_with_mode(target_im):
                                            top//DOT_AREA_ONE_SIDE * THUMBNAIL_ONE_SIDE))
 
     mosaic_icon_im.save('product/my_icon_mosaic_mode.png')
+
+def extract_file_name(file_path):
+    """Extracts file name from file path (not including extension)
+
+    Args:
+        file_path: str
+            example: 'foo/bar.png'
+
+    Returns:
+        str
+            example: 'bar'
+
+    """
+    # ファイルパスからファイル名(拡張子含む)を取り出す
+    file_name = file_path.split('/')[-1]
+    # 拡張子を取り除く
+    return file_name.split('.')[0]
+
+def now_datetime():
+    """Returns current time as '%Y%m%d%H%M%S' string
+
+    Returns:
+        str
+            example: '20180331121251'
+                current time 2018/3/31 12:12:51
+    """
+    now = datetime.datetime.now()
+    return now.strftime('%Y%m%d%H%M%S')
 
 # このファイルではmodeになっているので注意
 def materials_list_from_file(filename):

--- a/mosaic_art_mode.py
+++ b/mosaic_art_mode.py
@@ -52,7 +52,9 @@ def create_mosaic_art_with_mode(target_im):
             mosaic_icon_im.paste(area_im, (left//DOT_AREA_ONE_SIDE * THUMBNAIL_ONE_SIDE,
                                            top//DOT_AREA_ONE_SIDE * THUMBNAIL_ONE_SIDE))
 
-    mosaic_icon_im.save('product/my_icon_mosaic_mode.png')
+    save_file_path = 'product/{}'.format(mosaic_art_mode_file_name(target_im))
+    print('Mosaic art created at', save_file_path)
+    mosaic_icon_im.save(save_file_path)
 
 def mosaic_art_mode_file_name(target_im):
     """Returns a file name from target image name


### PR DESCRIPTION
Issue #21 完成したモザイクアートのファイル名を区別する への対応。

モザイクアートのファイル名を以下のように修正した。
- 平均色どうしで作るモザイクアート：`<対象画像のファイル名>_mosaic_<YYYYmmddHHMMSS>.png`
- 中央色どうしで作るモザイクアート：`<対象画像のファイル名>_mosaic_median_<YYYYmmddHHMMSS>.png`
- 最瀕色どうしで作るモザイクアート：`<対象画像のファイル名>_mosaic_mode_<YYYYmmddHHMMSS>.png`

動作確認内容
- `mosaic_art.py` `now_datetime()`
年月日時分秒が14桁の数字(=4+2+2+2+2+2)で返っていることを確認
- `mosaic_art.py` `extract_file_name(file_path)`
以下のパターンのパスを渡し、拡張子を除いたファイル名が返ることを確認
    - ファイルパス中のフォルダが一つの場合（コード中の例の場合）：`foo/bar.png`
    - 同じフォルダ内に置かれたファイルの場合：`mofu.png`
    - 長いパスの場合：`~/Downloads/stash_LTdemo_image/slack.png`
    - 同じフォルダ内に置かれたファイルの別の指定パターン：`./mofu.png`
    - 上のフォルダを指定した場合：`../foo/bar.png`
    - png以外の拡張子の場合：`foo/bar.HEIC`
- `mosaic_art.py` `mosaic_art_file_name(target_im)`
以下のパターンのファイル名で確認
    - ファイルパス中のフォルダが一つの場合（コード中の例の場合）：`foo/bar.png`
    - 同じフォルダ内に置かれたファイルの場合：`mofu.png`
    - 長いパスの場合：`~/Downloads/stash_LTdemo_image/slack.png`
- `mosaic_art.py`
以下のパターンでモザイクアートを作成して動作することを確認
    - `python mosaic_art.py my_icon.png`
    - `python mosaic_art.py ~/Downloads/stash_LTdemo_image/slack.png`
- `mosaic_art_median.py` `mosaic_art_median_file_name(target_im)`
ファイルパス中のフォルダが一つの場合（コード中の例の場合）：`foo/bar.png`で確認
- `mosaic_art_median.py`
`python mosaic_art_median.py my_icon.png`でモザイクアートを作成して動作することを確認
- `mosaic_art_mode.py` `mosaic_art_mode_file_name(target_im)`
ファイルパス中のフォルダが一つの場合（コード中の例の場合）：`foo/bar.png`で確認
- `mosaic_art_mode.py`
`python mosaic_art_mode.py my_icon.png`でモザイクアートを作成して動作することを確認